### PR TITLE
feat : 수강평신고 조회 - 수강평 상태 변경 버튼 fix

### DIFF
--- a/src/main/java/com/launcher/inflaunch/service/AdminService.java
+++ b/src/main/java/com/launcher/inflaunch/service/AdminService.java
@@ -38,11 +38,8 @@ public class AdminService {
         Page<ReportReview> reportedReviewsPage = reportReviewRepository.findAll(pageable);
         List<ReportReviewInfoDto> reportReviewInfoDtos = new ArrayList<>();
 
-        log.info("plz : " + reportedReviewsPage);
-
         if (reportedReviewsPage.hasContent()) {
             for (ReportReview reportReview : reportedReviewsPage.getContent()) {
-                log.info("허허허 : " + reportedReviewsPage.getContent());
                 Review reportedReview = reportReview.getReview();
 
                 /* 신고되지 않은 수강평에 대한 정보는 노출할 필요가 없다. 하나라도 신고가 접수되면 admin이 확인할 수 있도록 한다. */
@@ -53,8 +50,6 @@ public class AdminService {
                     String reportReviewContent = reportReview.getContent();
                     Long reviewReportingUserId = reportReview.getUser().getId();
                     String reviewReportingUsername = reportReview.getUser().getUsername();
-
-                    log.info("for문 내부에서 수강평신고 정보 : " + reviewReportingUserId);
 
                     // 신고된 review 정보
                     Long reportedReviewId = reportedReview.getId();
@@ -72,14 +67,11 @@ public class AdminService {
                             reportedReviewId, reportedReviewWrite, reviewUserId, reviewUsername,
                             reportedReviewCourseId, reportedReviewCourseTitle, reportCount, reviewStatus
                     );
-                    log.info("Created ReportReviewInfoDto: {}", reportReviewInfoDto);
                     reportReviewInfoDtos.add(reportReviewInfoDto);
-                    log.info("plz 2 : {}", reportReviewInfoDtos);
                 }
             }
         }
 
-//        return reportReviewInfoDtos;
         return reportedReviewsPage.getTotalElements() == 0? new PageImpl<>(Collections.emptyList(), pageable, reportedReviewsPage.getTotalElements()) : new PageImpl<>(reportReviewInfoDtos, pageable, reportedReviewsPage.getTotalElements());
     }
 
@@ -89,8 +81,12 @@ public class AdminService {
         Review readyToBeUpdatedReview = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewNotFoundException(reviewId + "번 ID의 수강평이 존재하지 않습니다."));
 
+        log.info("2. Status 수정 시작");
+
         readyToBeUpdatedReview.setRegDate(readyToBeUpdatedReview.getRegDate());
         readyToBeUpdatedReview.setReviewStatus(reviewStatus);
+
         reviewRepository.save(readyToBeUpdatedReview);
+        log.info("3. ID {}번 수강평은 {} 처리하였습니다.", reviewId, reviewStatus);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.datasource.username=inflaunchuser
 spring.datasource.password=1234
 
 # JPA에서 생성되는 SQL 문을 콘솔 출력
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 
 # 쿼리가 훨씬 보기 좋게 정렬되어 로그 찍힌다
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/templates/views/admin/reportreview-page.html
+++ b/src/main/resources/templates/views/admin/reportreview-page.html
@@ -56,32 +56,25 @@
     <td th:text="${reportedReview.reviewReportingUsername}"></td>
 
     <td>
-      <form id="reviewForm" th:action="@{/admin/report-reviews}" method="post">
+      <form th:id="'reviewForm-' + ${reportedReview.reportedReviewId}" th:action="@{/admin/report-reviews}" method="post" onsubmit="return confirmReviewAction(event)">
         <input type="hidden" name="_method" value="patch" />
         <input type="hidden" name="reviewId" th:value="${reportedReview.reportedReviewId}" />
         <input type="hidden" name="currentPage" th:value="${currentPage}" />
-        <button type="submit" name="action" value="active" class="active-button" onclick="confirmReviewAction('active')">수강평 재노출</button>
-        <button type="submit" name="action" value="inactive" class="inactive-button" onclick="confirmReviewAction('inactive')">수강평 숨김</button>
+        <button type="submit" name="action" value="active" class="active-button">수강평 재노출</button>
+        <button type="submit" name="action" value="inactive" class="inactive-button">수강평 숨김</button>
       </form>
     </td>
 
     <script>
-      function confirmReviewAction(action) {
+      function confirmReviewAction(event) {
         var message = '';
+        var action = event.submitter.value;
         if (action === 'active') {
           message = '해당 수강평을 재노출하시겠습니까?';
         } else if (action === 'inactive') {
           message = '해당 수강평을 숨기시겠습니까?';
         }
-        if (confirm(message)) {
-          var form = document.getElementById('reviewForm');
-          var actionInput = document.createElement('input');
-          actionInput.type = 'hidden';
-          actionInput.name = 'action';
-          actionInput.value = action;
-          form.appendChild(actionInput);
-          form.submit();
-        }
+        return confirm(message);
       }
     </script>
 


### PR DESCRIPTION
- 수강평 상태 변경 버튼을 클릭하면, 한 번 확인하는 메시지 창에서 '취소'를 클릭하면 원래 페이지로 되돌아가야 하지만 -> '확인'과 동일하게 작동하여 수강평 상태를 변경시켜버리는 현상 발견 -> 수정 완료